### PR TITLE
Integrate lidarr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 # Upgradarr
 
-Inspired by Huntarr, but wanting to put my own rules on missing/upgrade search and download cleanup, I decided to write my own little script to interface with Sonarr and Radarr and stop me from having to manually fix these issues.
+Inspired by Huntarr, but wanting to put my own rules on missing/upgrade search and download cleanup, I decided to write my own little script to interface with Sonarr, Radarr, and Lidarr and stop me from having to manually fix these issues.
 This is a simple project I put together in very little time just to play around with docker support in .NET, and to sharpen my know-how.
 
 ## What does this do? 
 
 Upgradarr is built to: 
-- Search for missing monitored movies and TV shows;
-- Upgrade existing monitored movies and TV shows;
+- Search for missing monitored media (movies, TV shows, and music);
+- Upgrade existing monitored media;
 - Clean up stalled and stuck downloads, blocklist and search for replacements.
 
 ## What this doesn't do (yet) 
 
 What I'm still planning on implementing:
-- Multiple Sonarr/Radarr instances (anime, 4K/1080p splits);
+- Multiple Sonarr/Radarr/Lidarr instances (anime, 4K/1080p splits);
 - Stop searching on cutoff met;
 - UI for monitoring and configuration;
 - Better versioning.
 
 ## Wait, do I need this?
 
-Honestly? Probably not. Sonarr and Radarr do a great job of monitoring the RSS feeds for any new downloads that become available for your monitored titles. This will not replace that. You want to use Upgradarr if you:
-- Keep trying to find episodes for that one TV show and they're always stalling;
+Honestly? Probably not. Sonarr, Radarr, and Lidarr do a great job of monitoring the RSS feeds for any new downloads that become available for your monitored titles. This will not replace that. You want to use Upgradarr if you:
+- Keep trying to find items for a particular title and they're always stalling;
 - Already have a library, but would want to check if any of your titles has a better version out there;
-- Is tired of manually getting rid of downloads and you're not sure whether you'll find it when searching for a whole season or just a single episode;
+- Is tired of manually getting rid of downloads and you're not sure whether you'll find it when searching for a whole album/season or just a single track/episode;
 - Keep having file imports failing for compressed data and weird file extensions.
 
 ## How to use
@@ -38,6 +38,7 @@ services:
     environment:
       - Sonarr__ApiKey=${SONARR_KEY}
       - Radarr__ApiKey=${RADARR_KEY}
+      - Lidarr__ApiKey=${LIDARR_KEY}
     volumes:
       - /path/to/config:/config
 #    ports:
@@ -46,4 +47,4 @@ services:
 
 ## Are there any drawbacks?
 
-Yes. Upgradarr can be very eager to get rid of downloads, so if you have certain rules on seeding for your indexes, you might want to tweak the settings a little bit or skip this tool altogether. You might also see an increase in downloads for titles that can be just a sidegrade at best, or can replace your carefully chosen media. In these cases, I recommend unmonitoring the title/season/episode so that it doesn't try to replace your media (it might still try if another episode of the same season or another season of the same show is monitored)
+Yes. Upgradarr can be very eager to get rid of downloads, so if you have certain rules on seeding for your indexes, you might want to tweak the settings a little bit or skip this tool altogether. You might also see an increase in downloads for titles that can be just a sidegrade at best, or can replace your carefully chosen media. In these cases, I recommend unmonitoring the title/season/album so that it doesn't try to replace your media (it might still try if another item in the same group is monitored)

--- a/Upgradarr.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/Upgradarr.Application/Extensions/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Upgradarr.Application.Options;
 using Upgradarr.Application.Services;
 using Upgradarr.Data.Extensions;
 using Upgradarr.Domain.Interfaces;
+using Upgradarr.Integrations.Lidarr.Extensions;
 using Upgradarr.Integrations.Radarr.Extensions;
 using Upgradarr.Integrations.Sonarr.Extensions;
 
@@ -34,6 +35,7 @@ public static class ServiceCollectionExtensions
 
             services.AddRadarr();
             services.AddSonarr();
+            services.AddLidarr();
 
             return services;
         }

--- a/Upgradarr.Application/Upgradarr.Application.csproj
+++ b/Upgradarr.Application/Upgradarr.Application.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../Upgradarr.Integrations.Lidarr/Upgradarr.Integrations.Lidarr.csproj" />
     <ProjectReference Include="../Upgradarr.Integrations.Radarr/Upgradarr.Integrations.Radarr.csproj" />
     <ProjectReference Include="../Upgradarr.Integrations.Sonarr/Upgradarr.Integrations.Sonarr.csproj" />
     <ProjectReference Include="../Upgradarr.Data/Upgradarr.Data.csproj" />

--- a/Upgradarr.Domain/Enums/ItemType.cs
+++ b/Upgradarr.Domain/Enums/ItemType.cs
@@ -29,4 +29,14 @@ public enum ItemType
     /// A movie
     /// </summary>
     Movie = 4,
+
+    /// <summary>
+    /// A music artist
+    /// </summary>
+    Artist = 5,
+
+    /// <summary>
+    /// A music album
+    /// </summary>
+    Album = 6,
 }

--- a/Upgradarr.Domain/Enums/RecordSource.cs
+++ b/Upgradarr.Domain/Enums/RecordSource.cs
@@ -4,4 +4,5 @@ public enum RecordSource
 {
     Sonarr,
     Radarr,
+    Lidarr,
 }

--- a/Upgradarr.Integrations.Lidarr/Extensions/LoggerMessages.cs
+++ b/Upgradarr.Integrations.Lidarr/Extensions/LoggerMessages.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Logging;
+
+namespace Upgradarr.Integrations.Lidarr.Extensions;
+
+public static partial class LoggerMessages
+{
+    [LoggerMessage(EventId = 5030, Level = LogLevel.Warning, Message = "Artist {ArtistId} not found")]
+    public static partial void LogArtistNotFound(this ILogger logger, int artistId);
+
+    [LoggerMessage(EventId = 5031, Level = LogLevel.Information, Message = "Searching for artist: {ArtistName}")]
+    public static partial void LogSearchingForArtist(this ILogger logger, string artistName);
+
+    [LoggerMessage(EventId = 5032, Level = LogLevel.Information, Message = "Searching for album: {AlbumTitle}")]
+    public static partial void LogSearchingForAlbum(this ILogger logger, string albumTitle);
+
+    [LoggerMessage(EventId = 5033, Level = LogLevel.Error, Message = "Error processing artist upgrade for {ArtistId}")]
+    public static partial void LogErrorProcessingArtistUpgrade(this ILogger logger, Exception ex, int artistId);
+
+    [LoggerMessage(EventId = 5034, Level = LogLevel.Error, Message = "Error processing album upgrade for album {AlbumId}")]
+    public static partial void LogErrorProcessingAlbumUpgrade(this ILogger logger, Exception ex, int albumId);
+
+    [LoggerMessage(EventId = 5035, Level = LogLevel.Information, Message = "Artist {ArtistName} (ID: {ArtistId}) has ongoing downloads, skipping")]
+    public static partial void LogArtistHasOngoingDownloads(this ILogger logger, string artistName, int artistId);
+
+    [LoggerMessage(EventId = 5036, Level = LogLevel.Information, Message = "Album {AlbumTitle} (ID: {AlbumId}) is currently downloading, skipping")]
+    public static partial void LogAlbumIsDownloading(this ILogger logger, string albumTitle, int albumId);
+
+    [LoggerMessage(EventId = 5037, Level = LogLevel.Information, Message = "Artist {ArtistName} (ID: {ArtistId}) is no longer monitored, removing from queue")]
+    public static partial void LogArtistNoLongerMonitored(this ILogger logger, string artistName, int artistId);
+
+    [LoggerMessage(EventId = 5038, Level = LogLevel.Information, Message = "Album {AlbumTitle} (ID: {AlbumId}) is no longer monitored, removing from queue")]
+    public static partial void LogAlbumNoLongerMonitored(this ILogger logger, string albumTitle, int albumId);
+
+    [LoggerMessage(EventId = 5039, Level = LogLevel.Error, Message = "Error deleting queue item {ItemId}")]
+    public static partial void LogErrorDeletingQueueItem(this ILogger logger, Exception ex, int itemId);
+}

--- a/Upgradarr.Integrations.Lidarr/Extensions/ServiceCollectionExtensions.cs
+++ b/Upgradarr.Integrations.Lidarr/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,53 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Upgradarr.Domain.Enums;
+using Upgradarr.Domain.Interfaces;
+using Upgradarr.Integrations.Extensions;
+using Upgradarr.Integrations.Interfaces;
+using Upgradarr.Integrations.Lidarr.Options;
+
+namespace Upgradarr.Integrations.Lidarr.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    extension(IServiceCollection services)
+    {
+        public IServiceCollection AddLidarr()
+        {
+            services.AddIntegrationBase();
+            services.AddHybridCache();
+
+            services
+                .AddOptions<LidarrOptions>()
+                .Configure(
+                    (LidarrOptions opt, IServiceProvider sp) =>
+                    {
+                        sp.GetRequiredService<IConfiguration>().GetSection(LidarrOptions.SectionName).Bind(opt);
+                    }
+                );
+
+            services
+                .AddHttpClient<LidarrClient>()
+                .ConfigureHttpClient(
+                    (serviceProvider, client) =>
+                    {
+                        var options = serviceProvider.GetRequiredService<IOptionsMonitor<LidarrOptions>>().CurrentValue;
+                        client.BaseAddress = new Uri(options.BaseUrl);
+                        if (!string.IsNullOrEmpty(options.ApiKey))
+                        {
+                            client.DefaultRequestHeaders.Add("X-Api-Key", options.ApiKey);
+                        }
+                    }
+                );
+
+            services.AddKeyedTransient<IQueueManager>(RecordSource.Lidarr, (sp, _) => sp.GetRequiredService<LidarrClient>());
+            services.AddTransient(sp => sp.GetRequiredKeyedService<IQueueManager>(RecordSource.Lidarr));
+
+            services.AddKeyedTransient<IUpgradeManager>(RecordSource.Lidarr, (sp, _) => sp.GetRequiredService<LidarrClient>());
+            services.AddTransient(sp => sp.GetRequiredKeyedService<IUpgradeManager>(RecordSource.Lidarr));
+
+            return services;
+        }
+    }
+}

--- a/Upgradarr.Integrations.Lidarr/LidarrClient.cs
+++ b/Upgradarr.Integrations.Lidarr/LidarrClient.cs
@@ -1,0 +1,398 @@
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Logging;
+using Upgradarr.Domain.Entities;
+using Upgradarr.Domain.Enums;
+using Upgradarr.Domain.Interfaces;
+using Upgradarr.Domain.ValueObjects;
+using Upgradarr.Integrations.Interfaces;
+using Upgradarr.Integrations.Lidarr.Extensions;
+using Upgradarr.Integrations.Lidarr.Models;
+using Upgradarr.Integrations.Models;
+
+namespace Upgradarr.Integrations.Lidarr;
+
+public class LidarrClient : QueueManagerBase<LidarrQueueResource>, IQueueManager, IUpgradeManager
+{
+    private readonly HttpClient _client;
+    private readonly TimeProvider _timeProvider;
+    private readonly HybridCache _hybridCache;
+
+    public LidarrClient(HttpClient client, ILogger<LidarrClient> logger, TimeProvider timeProvider, HybridCache hybridCache)
+        : base(logger)
+    {
+        _client = client;
+        _timeProvider = timeProvider;
+        _hybridCache = hybridCache;
+    }
+
+    public RecordSource SourceName => RecordSource.Lidarr;
+
+    public bool CanHandle(ItemType itemType) => itemType is ItemType.Artist or ItemType.Album;
+
+    public async IAsyncEnumerable<UpgradeState> BuildQueueItemsAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var artists = await GetArtistsAsync(cancellationToken);
+
+        foreach (var artist in artists.Where(a => a.Monitored))
+        {
+            var items = await BuildArtistQueueItemsAsync(artist, cancellationToken);
+            foreach (var item in items)
+            {
+                yield return item;
+            }
+        }
+    }
+
+    public async IAsyncEnumerable<UpgradeState> GetNewQueueItemsAsync(
+        HashSet<int> existingIds,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default
+    )
+    {
+        var artists = await GetArtistsAsync(cancellationToken);
+
+        foreach (var artist in artists.Where(a => a.Monitored && !existingIds.Contains(a.Id)))
+        {
+            var items = await BuildArtistQueueItemsAsync(artist, cancellationToken);
+            foreach (var item in items)
+            {
+                yield return item;
+            }
+        }
+    }
+
+    private async Task<List<UpgradeState>> BuildArtistQueueItemsAsync(ArtistResource artist, CancellationToken cancellationToken)
+    {
+        var queueItems = new List<UpgradeState>();
+
+        var artistItem = new UpgradeState
+        {
+            ItemId = artist.Id,
+            Title = artist.ArtistName,
+            ItemType = ItemType.Artist,
+            SearchState = SearchState.Pending,
+            IsMonitored = true,
+            CreatedAt = _timeProvider.GetUtcNow(),
+        };
+        queueItems.Add(artistItem);
+
+        var albums = await GetAlbumsAsync(artistId: artist.Id, cancellationToken: cancellationToken);
+
+        foreach (var album in albums.Where(a => a.Monitored))
+        {
+            bool isMissing = album.Statistics?.TrackFileCount == 0 && album.Statistics?.TotalTrackCount > 0;
+
+            var albumItem = new UpgradeState
+            {
+                ItemId = album.Id,
+                ParentSeriesId = artist.Id,
+                Title = $"{artist.ArtistName} - {album.Title}",
+                ItemType = ItemType.Album,
+                SearchState = SearchState.Pending,
+                IsMonitored = true,
+                IsMissing = isMissing,
+                ReleaseDate = album.ReleaseDate,
+                CreatedAt = _timeProvider.GetUtcNow(),
+            };
+            queueItems.Add(albumItem);
+
+            if (isMissing)
+            {
+                artistItem.IsMissing = true;
+            }
+        }
+
+        return queueItems;
+    }
+
+    public async Task<UpgradeActionResult> ProcessUpgradeAsync(UpgradeState state, CancellationToken cancellationToken = default)
+    {
+        return state.ItemType switch
+        {
+            ItemType.Artist => await ProcessArtistUpgradeAsync(state, cancellationToken),
+            ItemType.Album => await ProcessAlbumUpgradeAsync(state, cancellationToken),
+            _ => UpgradeActionResult.Skipped,
+        };
+    }
+
+    private async Task<UpgradeActionResult> ProcessArtistUpgradeAsync(UpgradeState state, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var artist = await GetArtistByIdAsync(state.ItemId, cancellationToken);
+            if (artist is null)
+            {
+                _logger.LogArtistNotFound(state.ItemId);
+                return UpgradeActionResult.Searched;
+            }
+
+            if (!artist.Monitored)
+            {
+                _logger.LogArtistNoLongerMonitored(artist.ArtistName ?? "Unknown", state.ItemId);
+                return UpgradeActionResult.Removed;
+            }
+
+            _logger.LogSearchingForArtist(artist.ArtistName ?? "Unknown");
+            await SearchArtistAsync(state.ItemId, cancellationToken);
+            return UpgradeActionResult.Searched;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogErrorProcessingArtistUpgrade(ex, state.ItemId);
+            return UpgradeActionResult.Skipped;
+        }
+    }
+
+    private async Task<UpgradeActionResult> ProcessAlbumUpgradeAsync(UpgradeState state, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var album = await GetAlbumByIdAsync(state.ItemId, cancellationToken);
+            if (album is null)
+            {
+                _logger.LogAlbumNoLongerMonitored(state.Title ?? "Unknown", state.ItemId);
+                return UpgradeActionResult.Searched;
+            }
+
+            if (!album.Monitored)
+            {
+                _logger.LogAlbumNoLongerMonitored(album.Title ?? "Unknown", state.ItemId);
+                return UpgradeActionResult.Removed;
+            }
+
+            if (await HasAlbumOngoingDownloadAsync(state, cancellationToken))
+            {
+                return UpgradeActionResult.Skipped;
+            }
+
+            _logger.LogSearchingForAlbum(album.Title ?? "Unknown");
+            await SearchAlbumsAsync([state.ItemId], cancellationToken);
+            return UpgradeActionResult.Searched;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogErrorProcessingAlbumUpgrade(ex, state.ItemId);
+            return UpgradeActionResult.Skipped;
+        }
+    }
+
+    public async Task<bool> HasOngoingDownloadAsync(UpgradeState state, CancellationToken cancellationToken = default)
+    {
+        return state.ItemType switch
+        {
+            ItemType.Artist => await HasArtistOngoingDownloadAsync(state, cancellationToken),
+            ItemType.Album => await HasAlbumOngoingDownloadAsync(state, cancellationToken),
+            _ => false,
+        };
+    }
+
+    private async Task<bool> HasArtistOngoingDownloadAsync(UpgradeState state, CancellationToken cancellationToken)
+    {
+        var queue = GetAllQueueItems(cancellationToken);
+        if (await queue.AnyAsync(q => q is LidarrQueueResource lidarrResource && lidarrResource.ArtistId == state.ItemId, cancellationToken: cancellationToken))
+        {
+            _logger.LogArtistHasOngoingDownloads(state.Title ?? "Unknown", state.ItemId);
+            return true;
+        }
+        return false;
+    }
+
+    private async Task<bool> HasAlbumOngoingDownloadAsync(UpgradeState state, CancellationToken cancellationToken)
+    {
+        var queue = GetAllQueueItems(cancellationToken);
+        if (await queue.AnyAsync(q => q is LidarrQueueResource lidarrResource && lidarrResource.AlbumId == state.ItemId, cancellationToken: cancellationToken))
+        {
+            _logger.LogAlbumIsDownloading(state.Title ?? "Unknown", state.ItemId);
+            return true;
+        }
+        return false;
+    }
+
+    public async Task<IList<ArtistResource>> GetArtistsAsync(CancellationToken cancellationToken = default) =>
+        await _hybridCache.GetOrCreateAsync(
+            "lidarr_artists",
+            async ct => await _client.GetFromJsonAsync("/api/v1/artist", LidarrClientJsonSerializerContext.Default.IListArtistResource, ct) ?? [],
+            options: null,
+            tags: ["lidarr", "lidarr_artists"],
+            cancellationToken: cancellationToken
+        );
+
+    public async Task<ArtistResource?> GetArtistByIdAsync(int id, CancellationToken cancellationToken = default) =>
+        await _hybridCache.GetOrCreateAsync(
+            $"lidarr_artist_{id}",
+            async ct => await _client.GetFromJsonAsync($"/api/v1/artist/{id}", LidarrClientJsonSerializerContext.Default.ArtistResource, ct),
+            options: null,
+            tags: ["lidarr", "lidarr_artists", $"lidarr_artist_{id}"],
+            cancellationToken: cancellationToken
+        );
+
+    public async Task<IList<AlbumResource>> GetAlbumsAsync(
+        int? artistId = null,
+        IList<int>? albumIds = null,
+        string? foreignAlbumId = null,
+        bool includeAllArtistAlbums = false,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var queryBuilder = new QueryBuilder();
+        if (artistId.HasValue)
+            queryBuilder.Add("artistId", artistId.Value.ToString());
+        if (foreignAlbumId != null)
+            queryBuilder.Add("foreignAlbumId", foreignAlbumId);
+        if (includeAllArtistAlbums)
+            queryBuilder.Add("includeAllArtistAlbums", "true");
+        if (albumIds?.Count > 0)
+            foreach (var id in albumIds)
+                queryBuilder.Add("albumIds", id.ToString());
+
+        return await _client.GetFromJsonAsync(
+                $"/api/v1/album{queryBuilder.ToQueryString()}",
+                LidarrClientJsonSerializerContext.Default.IListAlbumResource,
+                cancellationToken
+            ) ?? [];
+    }
+
+    public async Task<AlbumResource?> GetAlbumByIdAsync(int id, CancellationToken cancellationToken = default) =>
+        await _hybridCache.GetOrCreateAsync(
+            $"lidarr_album_{id}",
+            async ct => await _client.GetFromJsonAsync($"/api/v1/album/{id}", LidarrClientJsonSerializerContext.Default.AlbumResource, ct),
+            options: null,
+            tags: ["lidarr", "lidarr_albums", $"lidarr_album_{id}"],
+            cancellationToken: cancellationToken
+        );
+
+    public async Task<PagingResource<LidarrQueueResource>> GetQueueAsync(
+        int page = 1,
+        int pageSize = 10,
+        string? sortKey = null,
+        string? sortDirection = null,
+        bool includeArtist = false,
+        bool includeAlbum = false,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var queryBuilder = new QueryBuilder { { "page", page.ToString() }, { "pageSize", pageSize.ToString() } };
+        if (!string.IsNullOrEmpty(sortKey))
+            queryBuilder.Add("sortKey", sortKey);
+        if (!string.IsNullOrEmpty(sortDirection))
+            queryBuilder.Add("sortDirection", sortDirection);
+        if (includeArtist)
+            queryBuilder.Add("includeArtist", "true");
+        if (includeAlbum)
+            queryBuilder.Add("includeAlbum", "true");
+
+        return await _client.GetFromJsonAsync(
+                $"/api/v1/queue{queryBuilder.ToQueryString()}",
+                LidarrClientJsonSerializerContext.Default.PagingResourceLidarrQueueResource,
+                cancellationToken
+            ) ?? new();
+    }
+
+    public async Task<CommandResource?> SearchArtistAsync(int artistId, CancellationToken cancellationToken = default)
+    {
+        var command = new ArtistSearchCommand { ArtistId = artistId };
+        var response = await _client.PostAsJsonAsync(
+            "/api/v1/command",
+            command,
+            LidarrClientJsonSerializerContext.Default.ArtistSearchCommand,
+            cancellationToken
+        );
+        return await response.Content.ReadFromJsonAsync(LidarrClientJsonSerializerContext.Default.CommandResource, cancellationToken);
+    }
+
+    public async Task<CommandResource?> SearchAlbumsAsync(IList<int> albumIds, CancellationToken cancellationToken = default)
+    {
+        var command = new AlbumSearchCommand { AlbumIds = albumIds };
+        var response = await _client.PostAsJsonAsync(
+            "/api/v1/command",
+            command,
+            LidarrClientJsonSerializerContext.Default.AlbumSearchCommand,
+            cancellationToken
+        );
+        return await response.Content.ReadFromJsonAsync(LidarrClientJsonSerializerContext.Default.CommandResource, cancellationToken);
+    }
+
+    protected override async Task<bool> DeleteQueueItemAsync(
+        int itemId,
+        bool removeFromClient = true,
+        bool blocklist = false,
+        bool skipRedownload = false,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var queryBuilder = new QueryBuilder
+        {
+            { "removeFromClient", removeFromClient.ToString().ToLower() },
+            { "blocklist", blocklist.ToString().ToLower() },
+            { "skipRedownload", skipRedownload.ToString().ToLower() },
+        };
+        try
+        {
+            var response = await _client.DeleteAsync($"/api/v1/queue/{itemId}{queryBuilder.ToQueryString()}", cancellationToken);
+            response.EnsureSuccessStatusCode();
+            await _hybridCache.RemoveByTagAsync("lidarr", cancellationToken);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogErrorDeletingQueueItem(ex, itemId);
+            return false;
+        }
+    }
+
+    protected override Task<IEnumerable<ItemToQueue>> GetRequeueItemsAsync(int itemId, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IEnumerable<ItemToQueue>>([new(ItemType.Album, itemId)]);
+    }
+
+    protected override Task<PagingResource<LidarrQueueResource>> GetQueuePageAsync(int page, int pageSize, CancellationToken cancellationToken)
+    {
+        return GetQueueAsync(page, pageSize, includeArtist: true, includeAlbum: true, cancellationToken: cancellationToken);
+    }
+
+    protected override async Task<IQueueResource> ProcessQueueItemForYieldAsync(LidarrQueueResource item, CancellationToken cancellationToken)
+    {
+        if (item.DownloadId != null && item.DownloadId.Equals(item.Title, StringComparison.OrdinalIgnoreCase) && item.AlbumId.HasValue)
+        {
+            var album = await GetAlbumByIdAsync(item.AlbumId.Value, cancellationToken);
+            if (album is not null)
+            {
+                var artistName = album.Artist?.ArtistName ?? item.Artist?.ArtistName;
+                return item with { Title = artistName != null ? $"{artistName} - {album.Title}" : album.Title };
+            }
+        }
+        return item;
+    }
+
+    public async ValueTask<(bool ShouldRemove, int DownloadedScore)> ShouldRemoveImmediately(IQueueResource item, CancellationToken cancellationToken = default)
+    {
+        if (item is not LidarrQueueResource lidarrItem || !lidarrItem.AlbumId.HasValue)
+        {
+            return (false, 0);
+        }
+
+        var album = await GetAlbumByIdAsync(lidarrItem.AlbumId.Value, cancellationToken);
+        if (album?.Statistics is null || album.Statistics.TrackFileCount == 0)
+        {
+            return (false, 0);
+        }
+
+        // Album has downloaded files, compare scores
+        var shouldRemove = item.CustomFormatScore <= 0;
+        return (shouldRemove, 0);
+    }
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, UseStringEnumConverter = true)]
+[JsonSerializable(typeof(IList<ArtistResource>))]
+[JsonSerializable(typeof(ArtistResource))]
+[JsonSerializable(typeof(IList<AlbumResource>))]
+[JsonSerializable(typeof(AlbumResource))]
+[JsonSerializable(typeof(PagingResource<LidarrQueueResource>))]
+[JsonSerializable(typeof(CommandResource))]
+[JsonSerializable(typeof(ArtistSearchCommand))]
+[JsonSerializable(typeof(AlbumSearchCommand))]
+internal partial class LidarrClientJsonSerializerContext : JsonSerializerContext;

--- a/Upgradarr.Integrations.Lidarr/Models/AlbumResource.cs
+++ b/Upgradarr.Integrations.Lidarr/Models/AlbumResource.cs
@@ -1,0 +1,26 @@
+using Upgradarr.Integrations.Models;
+
+namespace Upgradarr.Integrations.Lidarr.Models;
+
+public record AlbumResource
+{
+    public int Id { get; init; }
+    public string? Title { get; init; }
+    public string? Disambiguation { get; init; }
+    public string? Overview { get; init; }
+    public int ArtistId { get; init; }
+    public ArtistResource? Artist { get; init; }
+    public string? ForeignAlbumId { get; init; }
+    public bool Monitored { get; init; }
+    public bool AnyReleaseOk { get; init; }
+    public int ProfileId { get; init; }
+    public int Duration { get; init; }
+    public string? AlbumType { get; init; }
+    public IEnumerable<string>? SecondaryTypes { get; init; }
+    public Ratings? Ratings { get; init; }
+    public DateTimeOffset? ReleaseDate { get; init; }
+    public IEnumerable<string>? Genres { get; init; }
+    public IEnumerable<MediaCover>? Images { get; init; }
+    public string? RemoteCover { get; init; }
+    public AlbumStatisticsResource? Statistics { get; init; }
+}

--- a/Upgradarr.Integrations.Lidarr/Models/AlbumSearchCommand.cs
+++ b/Upgradarr.Integrations.Lidarr/Models/AlbumSearchCommand.cs
@@ -1,0 +1,7 @@
+namespace Upgradarr.Integrations.Lidarr.Models;
+
+public record AlbumSearchCommand
+{
+    public string Name { get; } = "AlbumSearch";
+    public required IList<int> AlbumIds { get; init; }
+}

--- a/Upgradarr.Integrations.Lidarr/Models/AlbumStatisticsResource.cs
+++ b/Upgradarr.Integrations.Lidarr/Models/AlbumStatisticsResource.cs
@@ -1,0 +1,10 @@
+namespace Upgradarr.Integrations.Lidarr.Models;
+
+public record AlbumStatisticsResource
+{
+    public int TrackFileCount { get; init; }
+    public int TrackCount { get; init; }
+    public int TotalTrackCount { get; init; }
+    public long SizeOnDisk { get; init; }
+    public double PercentOfTracks { get; init; }
+}

--- a/Upgradarr.Integrations.Lidarr/Models/ArtistResource.cs
+++ b/Upgradarr.Integrations.Lidarr/Models/ArtistResource.cs
@@ -1,0 +1,27 @@
+using Upgradarr.Integrations.Models;
+
+namespace Upgradarr.Integrations.Lidarr.Models;
+
+public record ArtistResource
+{
+    public int Id { get; init; }
+    public string? ArtistName { get; init; }
+    public string? SortName { get; init; }
+    public string? Overview { get; init; }
+    public string? ArtistType { get; init; }
+    public string? Disambiguation { get; init; }
+    public string? ForeignArtistId { get; init; }
+    public bool Monitored { get; init; }
+    public string? Path { get; init; }
+    public string? RootFolderPath { get; init; }
+    public string? Folder { get; init; }
+    public int QualityProfileId { get; init; }
+    public int MetadataProfileId { get; init; }
+    public IEnumerable<string>? Genres { get; init; }
+    public IEnumerable<MediaCover>? Images { get; init; }
+    public string? RemotePoster { get; init; }
+    public IEnumerable<int>? Tags { get; init; }
+    public DateTimeOffset Added { get; init; }
+    public Ratings? Ratings { get; init; }
+    public ArtistStatisticsResource? Statistics { get; init; }
+}

--- a/Upgradarr.Integrations.Lidarr/Models/ArtistSearchCommand.cs
+++ b/Upgradarr.Integrations.Lidarr/Models/ArtistSearchCommand.cs
@@ -1,0 +1,7 @@
+namespace Upgradarr.Integrations.Lidarr.Models;
+
+public record ArtistSearchCommand
+{
+    public string Name { get; } = "ArtistSearch";
+    public required int ArtistId { get; init; }
+}

--- a/Upgradarr.Integrations.Lidarr/Models/ArtistStatisticsResource.cs
+++ b/Upgradarr.Integrations.Lidarr/Models/ArtistStatisticsResource.cs
@@ -1,0 +1,11 @@
+namespace Upgradarr.Integrations.Lidarr.Models;
+
+public record ArtistStatisticsResource
+{
+    public int AlbumCount { get; init; }
+    public int TrackFileCount { get; init; }
+    public int TrackCount { get; init; }
+    public int TotalTrackCount { get; init; }
+    public long SizeOnDisk { get; init; }
+    public double PercentOfTracks { get; init; }
+}

--- a/Upgradarr.Integrations.Lidarr/Models/LidarrQueueResource.cs
+++ b/Upgradarr.Integrations.Lidarr/Models/LidarrQueueResource.cs
@@ -1,0 +1,38 @@
+using System.Text.Json.Serialization;
+using Upgradarr.Domain.Enums;
+using Upgradarr.Integrations.Enums;
+using Upgradarr.Integrations.Interfaces;
+using Upgradarr.Integrations.Models;
+
+namespace Upgradarr.Integrations.Lidarr.Models;
+
+public record LidarrQueueResource : IQueueResource
+{
+    public DateTimeOffset? Added { get; init; }
+
+    // public IEnumerable<CustomFormatResource>? CustomFormats { get; init; }
+    public int CustomFormatScore { get; init; }
+    public string? DownloadClient { get; init; }
+    public bool DownloadClientHasPostImportCategory { get; init; }
+    public string? DownloadId { get; init; }
+    public string? ErrorMessage { get; init; }
+    public DateTimeOffset? EstimatedCompletionTime { get; init; }
+    public int Id { get; init; }
+    public string? Indexer { get; init; }
+    public string? OutputPath { get; init; }
+    public DownloadProtocol Protocol { get; init; }
+    public int? ArtistId { get; init; }
+    public int? AlbumId { get; init; }
+    public ArtistResource? Artist { get; init; }
+    public AlbumResource? Album { get; init; }
+    public double? Size { get; init; }
+    public QueueStatus Status { get; init; }
+    public QualityModel? Quality { get; init; }
+    public IEnumerable<TrackedDownloadStatusMessage>? StatusMessages { get; init; }
+    public string? Title { get; init; }
+    public TrackedDownloadState TrackedDownloadState { get; init; }
+    public TrackedDownloadStatus TrackedDownloadStatus { get; init; }
+
+    [JsonIgnore]
+    public RecordSource Source => RecordSource.Lidarr;
+}

--- a/Upgradarr.Integrations.Lidarr/Models/TrackFileResource.cs
+++ b/Upgradarr.Integrations.Lidarr/Models/TrackFileResource.cs
@@ -1,0 +1,18 @@
+using Upgradarr.Integrations.Models;
+
+namespace Upgradarr.Integrations.Lidarr.Models;
+
+public record TrackFileResource
+{
+    public int Id { get; init; }
+    public int ArtistId { get; init; }
+    public int AlbumId { get; init; }
+    public string? Path { get; init; }
+    public long Size { get; init; }
+    public DateTimeOffset DateAdded { get; init; }
+    public string? SceneName { get; init; }
+    public string? ReleaseGroup { get; init; }
+    public QualityModel? Quality { get; init; }
+    public int CustomFormatScore { get; init; }
+    public bool QualityCutoffNotMet { get; init; }
+}

--- a/Upgradarr.Integrations.Lidarr/Options/LidarrOptions.cs
+++ b/Upgradarr.Integrations.Lidarr/Options/LidarrOptions.cs
@@ -1,0 +1,9 @@
+namespace Upgradarr.Integrations.Lidarr.Options;
+
+public record LidarrOptions
+{
+    public const string SectionName = "Lidarr";
+
+    public required string BaseUrl { get; init; } = "http://lidarr:8686";
+    public string? ApiKey { get; init; }
+}

--- a/Upgradarr.Integrations.Lidarr/Upgradarr.Integrations.Lidarr.csproj
+++ b/Upgradarr.Integrations.Lidarr/Upgradarr.Integrations.Lidarr.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.3.9" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" Version="10.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Upgradarr.Integrations/Upgradarr.Integrations.csproj" />
+  </ItemGroup>
+</Project>

--- a/Upgradarr.Web/Pages/Cleanups.razor
+++ b/Upgradarr.Web/Pages/Cleanups.razor
@@ -15,12 +15,11 @@ else
     <FluentButton Appearance="Appearance.Accent" OnClick="RunCleanup">Run Cleanup Now</FluentButton>
     <br/><br/>
     <div style="overflow-x: auto; width: 100%;">
-        <FluentDataGrid Items="@cleanups.AsQueryable()" Style="min-width: 700px; width: 100%;" GridTemplateColumns="1fr 2fr 1fr 1fr 1fr">
+        <FluentDataGrid Items="@cleanups.AsQueryable()" Style="min-width: 700px; width: 100%;" GridTemplateColumns="2fr 1fr 1fr 1fr">
             <PropertyColumn Title="Title" Property="@(p => p.Title ?? "Unknown")" Sortable="true" />
-            <PropertyColumn Title="Download ID" Property="@(p => p.DownloadId)" Sortable="true" />
             <PropertyColumn Title="Source" Property="@(p => p.Source)" Sortable="true" />
-            <PropertyColumn Title="Added" Property="@(p => p.Added)" Sortable="true" Format="yyyy-MM-dd HH:mm" />
-            <PropertyColumn Title="Remove At" Property="@(p => p.RemoveAt)" Sortable="true" Format="yyyy-MM-dd HH:mm" />
+            <PropertyColumn Title="Added" Property="@(p => p.Added)" Sortable="true" Format="HH:mm dd-MMM-yyyy" />
+            <PropertyColumn Title="Remove At" Property="@(p => p.RemoveAt)" Sortable="true" Format="HH:mm dd-MMM-yyyy" />
         </FluentDataGrid>
     </div>
 }

--- a/Upgradarr.Web/Pages/Upgrades.razor
+++ b/Upgradarr.Web/Pages/Upgrades.razor
@@ -16,7 +16,7 @@
 else
 {
     <div style="overflow-x: auto; width: 100%;">
-        <FluentDataGrid Items="@upgrades.AsQueryable()" Style="min-width: 600px; width: 100%;" GridTemplateColumns="1fr 1fr 1fr 1fr">
+        <FluentDataGrid Items="@upgrades.AsQueryable()" Style="min-width: 600px; width: 100%;" GridTemplateColumns="2fr 1fr 1fr 1fr">
             <PropertyColumn Title="Title" Property="@(p => p.Title ?? "Unknown")" Sortable="true" />
             <PropertyColumn Title="Type" Property="@(p => p.ItemType)" Sortable="true" />
             <PropertyColumn Title="State" Property="@(p => p.SearchState)" Sortable="true" />

--- a/Upgradarr.slnx
+++ b/Upgradarr.slnx
@@ -11,6 +11,7 @@
   </Folder>
   <Folder Name="/2 - Integrations/">
     <Project Path="Upgradarr.Integrations/Upgradarr.Integrations.csproj" />
+    <Project Path="Upgradarr.Integrations.Lidarr/Upgradarr.Integrations.Lidarr.csproj" />
     <Project Path="Upgradarr.Integrations.Radarr/Upgradarr.Integrations.Radarr.csproj" />
     <Project Path="Upgradarr.Integrations.Sonarr/Upgradarr.Integrations.Sonarr.csproj" />
   </Folder>


### PR DESCRIPTION
Initial support for Lidarr API and calls. I'm still in the process of improving how data for each app is saved, but that can't come before .NET 11 EF Core's support for multiple json schemas in a single column, so this is the bare minimum for that.
This should work exactly as before, where it will look for missing content, and then upgrades for existing content.

Closes #4 